### PR TITLE
Update Dev Build workflow to v6 checkout

### DIFF
--- a/.github/workflows/dev-build-reusable-workflow.yaml
+++ b/.github/workflows/dev-build-reusable-workflow.yaml
@@ -45,7 +45,7 @@ jobs:
       image-digest: ${{ steps.docker_build.outputs.digest }}
     steps:
       - name: Checkout source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx (with mirror)
         if: inputs.use-dockerhub-mirror
@@ -85,7 +85,7 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - name: Checkout GitOps repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.gitops-repo }}
           token: ${{ secrets.workflow-token }}


### PR DESCRIPTION
Closes #13 

Dev Build for PRs was using v4 checkout. This updates it to v6.