### PR TITLE
Remove the branch from the workflow

### DIFF
--- a/.github/workflows/create-fase-ghcr-image.yaml
+++ b/.github/workflows/create-fase-ghcr-image.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - remove-yq-action
     paths:
       - self-hosted-gh-runners/custom-image/Dockerfile
   workflow_dispatch:


### PR DESCRIPTION
I accidentally left this within the workflow. The image was already built from the branch so this isn't needed