### PR TITLE
Fix CM reusable workflow after image change

### DIFF
--- a/.github/workflows/dev-build-cm-reusable-workflow.yaml
+++ b/.github/workflows/dev-build-cm-reusable-workflow.yaml
@@ -136,8 +136,8 @@ jobs:
           cd gitops
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          CM="${{ inputs.configmap_name }}"
-          TARGET_DIR="./components/ua/user-exchange-client/user-exchange-client-chart/templates/client-configmaps-dev"                  
+          CM="${{ inputs.configmap_name }}"          
+          TARGET_DIR="./components/ua/user-exchange-client/user-exchange-client-chart/config-maps/dev"                  
           cp "/tmp/${CM}.yaml" "${TARGET_DIR}/${CM}.yaml"          
           git add "${TARGET_DIR}/${CM}.yaml"
           GITOPS_SHA=$(git rev-parse --short HEAD)

--- a/.github/workflows/dev-build-cm-reusable-workflow.yaml
+++ b/.github/workflows/dev-build-cm-reusable-workflow.yaml
@@ -141,5 +141,5 @@ jobs:
           cp "/tmp/${CM}.yaml" "${TARGET_DIR}/${CM}.yaml"          
           git add "${TARGET_DIR}/${CM}.yaml"
           GITOPS_SHA=$(git rev-parse --short HEAD)
-          git commit -m "[CD] Update ${{ inputs.app-name }} with commit ${GITOPS_SHA} - src: https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+          git commit -m "[CD] Update User exchange client - ${{ inputs.app-name }} with commit ${GITOPS_SHA} - src: https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
           git push

--- a/.github/workflows/dev-build-cm-reusable-workflow.yaml
+++ b/.github/workflows/dev-build-cm-reusable-workflow.yaml
@@ -101,14 +101,14 @@ jobs:
  
           kubectl create cm "${{ inputs.configmap_name }}" --from-file="${FILE}" --dry-run=client -o yaml > /tmp/"${{ inputs.configmap_name }}".yaml
           echo "============= Generated manifest==================="
-          cat /tmp/"${{ inputs.configmap_name }}".yaml
+          cat /tmp/${{ inputs.configmap_name }}.yaml
           echo "===================================================" 
       
       - name: Upload generated configmap
         uses: actions/upload-artifact@v7
         with:
           name: configmap-${{ inputs.app-name }}
-          path: /tmp/"${{ inputs.configmap_name }}".yaml  
+          path: /tmp/${{ inputs.configmap_name }}.yaml  
 
   update_gitops:
     name: Update GitOps Repository
@@ -138,7 +138,7 @@ jobs:
           git config --local user.name "GitHub Action"
           CM="${{ inputs.configmap_name }}"
           TARGET_DIR="./components/ua/user-exchange-client/user-exchange-client-chart/templates/client-configmaps-dev"                  
-          cp /tmp/"${CM}".yaml "${TARGET_DIR}/${CM}.yaml"          
+          cp "/tmp/${CM}.yaml" "${TARGET_DIR}/${CM}.yaml"          
           git add "${TARGET_DIR}/${CM}.yaml"
           GITOPS_SHA=$(git rev-parse --short HEAD)
           git commit -m "[CD] Update ${{ inputs.app-name }} with commit ${GITOPS_SHA} - src: https://github.com/${{ github.repository }}/commit/${{ github.sha }}"


### PR DESCRIPTION
closes : #61 
- removes `""` as we are using bash shell as default
- fixes broken configmap path 
- fixes commit message - includes application name in commit message 