### PR TITLE
Update GHCR permissions for workflow jobs

### DIFF
--- a/.github/workflows/build-and-prepare-release-reusable-workflow.yaml
+++ b/.github/workflows/build-and-prepare-release-reusable-workflow.yaml
@@ -205,6 +205,7 @@ jobs:
     needs: build_and_push
     permissions:
       contents: write
+      packages: read
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v6
@@ -226,6 +227,7 @@ jobs:
       contents: write
       discussions: write
       pull-requests: read
+      packages: read
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v6
@@ -259,6 +261,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      packages: read
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v6

--- a/self-hosted-gh-runners/kubernetes/deploy.sh
+++ b/self-hosted-gh-runners/kubernetes/deploy.sh
@@ -15,6 +15,8 @@ kubectl create secret generic fase-gh-runners \
   --namespace "${RUNNER_NAMESPACE}" \
   --from-literal=github_token="${ACCESS_TOKEN}" || echo "Secret exists, or errored on creation"
 
+kubectl apply --namespace "${RUNNER_NAMESPACE}" -f hook-extension.yaml || echo "Hook Extension exists, or errored on creation"
+
 helm upgrade --install arc \
   --namespace "${CONTROLLER_NAMESPACE}" \
   --version "${CHART_VERSION}" \

--- a/self-hosted-gh-runners/kubernetes/hook-extension.yaml
+++ b/self-hosted-gh-runners/kubernetes/hook-extension.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hook-extension
-  namespace: arc-gh-runners
+  namespace: fase-gh-runners
 data:
   content: |
     spec:


### PR DESCRIPTION
When a workflow uses the fase custom image for a workflow, it needs pull permission from ghcr.io to create the container.

Setting top level workflow permissions is usually good enough, until a job specifies its own permissions.

No matter what the job permissions are they overwrite the workflow level permissions.

All jobs using `ghcr.io/isisbusapps/fase-gh-runner-container:latest` need to have `packages: read` as a permission.